### PR TITLE
Assert on future when login via web provider

### DIFF
--- a/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
+++ b/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
@@ -52,10 +52,11 @@ class ConfiguredWebViewProvider: NSObject, Provider, SFSafariViewControllerDeleg
         origin: String,
         viewController: UIViewController?
     ) -> Future<AuthToken, ReachFiveError> {
-        self.promise?.failure(.AuthCanceled)
+        self.promise?.tryFailure(.AuthCanceled)
         let promise = Promise<AuthToken, ReachFiveError>()
         self.promise = promise
         self.pkce = Pkce.generate()
+        UserDefaultsStorage().save(key: "PASSWORDLESS_PKCE", value: pkce)
         let url = self.buildUrl(
             sdkConfig: sdkConfig,
             providerConfig: providerConfig,

--- a/Sandbox/Podfile.lock
+++ b/Sandbox/Podfile.lock
@@ -3,22 +3,22 @@ PODS:
   - AlamofireNetworkLogger (0.1.0):
     - Alamofire (~> 4.0)
   - BrightFutures (8.0.0)
-  - CryptoSwift (1.1.3)
+  - CryptoSwift (1.3.0)
   - FacebookCore (0.9.0):
     - FBSDKCoreKit (~> 5.0)
   - FacebookLogin (0.9.0):
     - FacebookCore (~> 0.9.0)
     - FBSDKCoreKit (~> 5.0)
     - FBSDKLoginKit (~> 5.0)
-  - FBSDKCoreKit (5.8.0):
-    - FBSDKCoreKit/Basics (= 5.8.0)
-    - FBSDKCoreKit/Core (= 5.8.0)
-  - FBSDKCoreKit/Basics (5.8.0)
-  - FBSDKCoreKit/Core (5.8.0):
+  - FBSDKCoreKit (5.15.1):
+    - FBSDKCoreKit/Basics (= 5.15.1)
+    - FBSDKCoreKit/Core (= 5.15.1)
+  - FBSDKCoreKit/Basics (5.15.1)
+  - FBSDKCoreKit/Core (5.15.1):
     - FBSDKCoreKit/Basics
-  - FBSDKLoginKit (5.8.0):
-    - FBSDKLoginKit/Login (= 5.8.0)
-  - FBSDKLoginKit/Login (5.8.0):
+  - FBSDKLoginKit (5.15.1):
+    - FBSDKLoginKit/Login (= 5.15.1)
+  - FBSDKLoginKit/Login (5.15.1):
     - FBSDKCoreKit (~> 5.0)
   - GoogleSignIn (4.4.0):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
@@ -32,19 +32,19 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
-  - GTMSessionFetcher/Core (1.3.0)
-  - IdentitySdkCore (5.2.0):
+  - GTMSessionFetcher/Core (1.3.1)
+  - IdentitySdkCore (5.2.1):
     - Alamofire (~> 4.9)
     - BrightFutures (~> 8.0)
     - CryptoSwift (~> 1.1)
-  - IdentitySdkFacebook (5.2.0):
+  - IdentitySdkFacebook (5.2.1):
     - FacebookCore (~> 0.9)
     - FacebookLogin (~> 0.9)
     - IdentitySdkCore (~> 5)
-  - IdentitySdkGoogle (5.2.0):
+  - IdentitySdkGoogle (5.2.1):
     - GoogleSignIn (~> 4.4)
     - IdentitySdkCore (~> 5)
-  - IdentitySdkWebView (5.2.0):
+  - IdentitySdkWebView (5.2.1):
     - IdentitySdkCore (~> 5)
 
 DEPENDENCIES:
@@ -82,18 +82,18 @@ SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   AlamofireNetworkLogger: 46481fa95498e8e035ea6b391b0b5870e356c532
   BrightFutures: f8427b46feabaf73c5e71ace7d86d65dfbb47696
-  CryptoSwift: 6b6e488df0598b3e9fa49254ed1a65e8c1b1e10b
+  CryptoSwift: 1283821600233bdbeb96d7b389c3288c3bf77211
   FacebookCore: ba86524b66cfa86d0f8e65d08faa8504a9f732dd
   FacebookLogin: 6cee9fd6e1fe976fe8f7eec199e27b28b14f5d63
-  FBSDKCoreKit: e7dcac0aabcfb09d0166998edd95fe3b05a0ce5d
-  FBSDKLoginKit: 1b0cf04df0370b37404213157b060d6666ede814
+  FBSDKCoreKit: 1d5acf7c9d7a2f92bb1a242dc60cae5b7adb91df
+  FBSDKLoginKit: f1ea8026a58b52d30c9f2e6a58ca7d813619fb83
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
-  GTMSessionFetcher: 43b8b64263023d4f32caa0b40f4c8bfa3c5f36d8
-  IdentitySdkCore: 2592987613bc59f107a7c3a9bb036a39d578b877
-  IdentitySdkFacebook: 66bf77a74d4163bcba9b7539b7310a3648bb5719
-  IdentitySdkGoogle: 43dd5694358c417f87e0056267b47c95f30b12c3
-  IdentitySdkWebView: 17523e199fb151130be95d7f1b88944c80de5719
+  GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
+  IdentitySdkCore: c35b32a24553a921fee76d80e59f770c075ef84a
+  IdentitySdkFacebook: a4f48cc49139da997055391d92c5d1f78b0b738b
+  IdentitySdkGoogle: 2b436a5a1dc18b5149a3d577a42f9090252a98e9
+  IdentitySdkWebView: b6abfb274970d6e849aaf2945443482921283789
 
 PODFILE CHECKSUM: 56f5a656f1cc6691838a6095e1102a8ef2988439
 


### PR DESCRIPTION
https://app.asana.com/0/870979095300532/1163323961211673/f
A `fatal error` was raised by an `assert()` whenever we try to resolve an already resolved promise.
I thought about adding a debug flag preventing the `assert()` evaluation in debug (aka. development mode), but not sure if it's a good practice so gave it up.
Also, added a fix concerning the PKCE code generation.