### PR TITLE
Reintroduce ReachFiveFidoClient.swift

### DIFF
--- a/IdentitySdkCore.podspec
+++ b/IdentitySdkCore.podspec
@@ -23,5 +23,6 @@ Pod::Spec.new do |spec|
   spec.dependency 'KeychainAccess', '~> 4.2.1'
   spec.dependency 'PromiseKit', '~> 6.13.1'
   spec.dependency 'CryptoSwift', '~> 1.3.8'
+  spec.dependency 'WebAuthnKit', '~> 0.9.6'
 
 end

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFive.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFive.swift
@@ -94,6 +94,34 @@ public class ReachFive: NSObject {
             .flatMap({ AuthToken.fromOpenIdTokenResponseFuture($0) })
     }
 
+    internal func signupWithWebAuthn(profile: ProfileWebAuthnSignupRequest,origin: String,friendlyName: String?,viewController: UIViewController,scopes: [String]?, completion: @escaping ((Future<AuthToken, ReachFiveError>) -> Any)) {
+        let webAuthnRegistrationRequest = WebAuthnRegistrationRequest(
+            origin: origin,
+            friendlyName: friendlyName ?? "",
+            profile: profile,
+            clientId: sdkConfig.clientId
+        )
+        // get registrationOptions
+        self.reachFiveApi
+            .createWebAuthnSignupOptions(webAuthnRegistrationRequest: webAuthnRegistrationRequest)
+            .onSuccess{registrationOptions in
+                // prepare and setup the reachFiveClientFido
+                let reachFiveClientFido = ReachFiveFidoClient (viewController: viewController, origin: origin)
+                reachFiveClientFido.setupWebAuthnClient()
+                reachFiveClientFido.startRegistration(registrationOption: registrationOptions).onSuccess{ webauthnSignupCredential in
+                    // start the onSignupWithWebAuthnResult func to get firstly the authenticationToken and then exchange the tkn with an access token
+                    self.onSignupWithWebAuthnResult(webauthnSignupCredential: webauthnSignupCredential,scopes: scopes)
+                    { (authToken) -> Any in
+                        _ = completion(authToken)
+                    }
+                }
+            }.onFailure { error in
+                let thePromise = BrightFutures.Promise<AuthToken, ReachFiveError>()
+                thePromise.failure(error)
+                _ = completion(thePromise.future)
+            }
+    }
+    
     private func onSignupWithWebAuthnResult(webauthnSignupCredential: WebauthnSignupCredential,scopes: [String]?, completion: @escaping ((Future<AuthToken, ReachFiveError>) -> Any)) {
         
         self.reachFiveApi
@@ -111,6 +139,35 @@ public class ReachFive: NSObject {
             }
     }
 
+    internal func loginWithWebAuthn(email: String, origin: String, scopes: [String]?,viewController: UIViewController, completion: @escaping ((Future<AuthToken, ReachFiveError>) -> Any)) {
+        
+        let webAuthnLoginRequest = WebAuthnLoginRequest(
+            clientId: sdkConfig.clientId,
+            origin: origin,
+            email: email,
+            scope: [String](scopes!).joined(separator: " ")
+        )
+        
+        self.reachFiveApi
+            .createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
+            .onSuccess { authenticationOptions in
+                
+                let reachFiveClientFido = ReachFiveFidoClient (viewController: viewController, origin: origin)
+                reachFiveClientFido.setupWebAuthnClient()
+                reachFiveClientFido.startAuthentication(authenticationOptions: authenticationOptions).onSuccess{ authenticationPublicKeyCredential in
+                    
+                    self.onLoginWithWebAuthnResult(authenticationPublicKeyCredential: authenticationPublicKeyCredential,scopes: scopes)
+                    { (authToken) -> Any in
+                        _ = completion(authToken)
+                    }
+                }
+            }.onFailure { error in
+                let thePromise = BrightFutures.Promise<AuthToken, ReachFiveError>()
+                thePromise.failure(error)
+                _ = completion(thePromise.future)
+            }
+    }
+    
     private func onLoginWithWebAuthnResult(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential, scopes: [String]?, completion: @escaping ((Future<AuthToken, ReachFiveError>) -> Any)) {
         self.reachFiveApi
             .authenticateWithWebAuthn(authenticationPublicKeyCredential: authenticationPublicKeyCredential)

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveFidoClient.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveFidoClient.swift
@@ -1,0 +1,173 @@
+import Foundation
+import PromiseKit
+import WebAuthnKit
+import BrightFutures
+
+extension Data {
+    struct HexEncodingOptions: OptionSet {
+        let rawValue: Int
+        static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
+    }
+    
+    func hexEncodedString(options: HexEncodingOptions = []) -> String {
+        let format = options.contains(.upperCase) ? "%02hhX" : "%02hhx"
+        return map { String(format: format, $0) }.joined()
+    }
+}
+
+public enum FormError : Error {
+    case missing(String)
+    case empty(String)
+}
+
+class ReachFiveFidoClient: NSObject
+{
+    var webAuthnClient: WebAuthnClient!
+    var userConsentUI: UserConsentUI!
+    let viewController: UIViewController
+    let origin: String
+    
+    public  init(viewController: UIViewController, origin: String) {
+        self.viewController = viewController
+        self.origin = origin
+    }
+    
+    func setupWebAuthnClient() {
+        WAKLogger.available = true
+        
+        self.userConsentUI = UserConsentUI(viewController: self.viewController)
+        self.userConsentUI.config.showRPInformation = false
+        self.userConsentUI.config.fieldTextLightColor = UIColor.black
+        let authenticator = InternalAuthenticator(ui: self.userConsentUI)
+        self.webAuthnClient = WebAuthnClient(
+            origin:        self.origin,
+            authenticator: authenticator
+        )
+    }
+    func startRegistration(registrationOption: RegistrationOptions) -> Future<WebauthnSignupCredential, Error> {
+        
+        var challenge = registrationOption.options.publicKey.challenge
+        let userId = registrationOption.options.publicKey.user.id
+        let userName = registrationOption.options.publicKey.user.name
+        let displayName = registrationOption.options.publicKey.user.displayName
+        let rpId = registrationOption.options.publicKey.rp.id
+        
+        let requireResidentKey = true
+        var options = PublicKeyCredentialCreationOptions()
+        challenge = base64urlToHexString(base64url: challenge)
+        
+        options.challenge = Bytes.fromHex(challenge)
+        options.user.id = Bytes.fromString(userId)
+        options.user.name = userName
+        options.user.displayName = displayName
+        options.rp.id = rpId
+        options.rp.name = rpId
+        
+        options.attestation = .direct
+        options.addPubKeyCredParam(alg: .es256)
+        options.authenticatorSelection = AuthenticatorSelectionCriteria(
+            requireResidentKey: requireResidentKey,
+            userVerification: UserVerificationRequirement.required
+        )
+        
+        let thePromise = BrightFutures.Promise<WebauthnSignupCredential, Error>()
+        firstly {
+            self.webAuthnClient.create(options)
+        }.done { credential in
+            
+            let rawId = credential.rawId.toHexString()
+            let credId = credential.id
+            let credType = credential.type.rawValue
+            let clientDataJSON = self.encodeClientDataJsonToBase64(clientDataJson: credential.response.clientDataJSON)
+            let attestationObject = Base64.encodeBase64URL(credential.response.attestationObject)
+            
+            let r5AuthenticatorAttestationResponse = R5AuthenticatorAttestationResponse(attestationObject: attestationObject,clientDataJSON: clientDataJSON)
+            
+            let registrationPublicKeyCredential = RegistrationPublicKeyCredential(id: credId,rawId: rawId,type: credType,response: r5AuthenticatorAttestationResponse)
+            
+            let webauthnSignupCredential = WebauthnSignupCredential (webauthnId: userId,publicKeyCredential: registrationPublicKeyCredential)
+            let result: Swift.Result<WebauthnSignupCredential, Error> = Swift.Result.success(webauthnSignupCredential)
+            thePromise.complete(result)
+            
+        }.catch { error in
+            thePromise.failure(error)
+        }
+        
+        return thePromise.future
+    }
+    
+    func base64urlToHexString(base64url: String) -> String {
+        var hexString = base64url
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        if hexString.count % 4 != 0 {
+            hexString.append(String(repeating: "=", count: 4 - hexString.count % 4))
+        }
+        if let data = Data(base64Encoded: hexString) {
+            hexString = data.hexEncodedString()
+        }
+        return hexString
+    }
+    
+    func encodeClientDataJsonToBase64(clientDataJson: String) -> String {
+        
+        let utf8str = clientDataJson.data(using: .utf8)
+        var encodeClientDataJSON = ""
+        if let base64Encoded = utf8str?.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0)) {
+            encodeClientDataJSON = base64Encoded
+        }
+        return encodeClientDataJSON
+    }
+    
+    func startAuthentication(authenticationOptions: AuthenticationOptions) -> Future<AuthenticationPublicKeyCredential, Error> {
+        var challenge = authenticationOptions.publicKey.challenge
+        let rpId = authenticationOptions.publicKey.rpId
+        
+        // Decode challenge from Base64Url to HexString
+        challenge = base64urlToHexString(base64url: challenge)
+        // prepare PublicKeyCredentialRequestOptions
+        var options = PublicKeyCredentialRequestOptions()
+        options.challenge = Bytes.fromHex(challenge)
+        options.rpId = rpId
+        options.userVerification = UserVerificationRequirement.required
+        
+        for allowCredentials in authenticationOptions.publicKey.allowCredentials! {
+            // Decode credentialId from Base64Url to HexString
+            allowCredentials.id = base64urlToHexString(base64url: allowCredentials.id)
+            if !allowCredentials.id.isEmpty {
+                options.addAllowCredential(
+                    credentialId: Bytes.fromHex(allowCredentials.id),
+                    transports:   [.internal_]
+                )
+            }
+        }
+        let thePromise = BrightFutures.Promise<AuthenticationPublicKeyCredential, Error>()
+        firstly {
+            self.webAuthnClient.get(options)
+        }.done { assertion in
+            
+            let user: [UInt8] = assertion.response.userHandle ?? []
+            let userName = String(data: Data(_: user), encoding: .utf8) ?? ""
+            let rawId = assertion.rawId.toHexString()
+            let credId = assertion.id
+            let credType = assertion.type.rawValue
+            let clientDataJSON = self.encodeClientDataJsonToBase64(clientDataJson: assertion.response.clientDataJSON)
+            let authenticatorData = Base64.encodeBase64URL(assertion.response.authenticatorData)
+            let signature = Base64.encodeBase64URL(assertion.response.signature)
+            let userHandle = userName
+            
+            let r5AuthenticatorAssertionResponse = R5AuthenticatorAssertionResponse (authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userHandle)
+            
+            let authenticationPublicKeyCredential = AuthenticationPublicKeyCredential (id: credId, rawId: rawId, type: credType, response: r5AuthenticatorAssertionResponse)
+            
+            let result: Swift.Result<AuthenticationPublicKeyCredential, Error> = Swift.Result.success(authenticationPublicKeyCredential)
+            thePromise.complete(result)
+            
+        }.catch { error in
+            thePromise.failure(error)
+        }
+        
+        return thePromise.future
+    }
+}
+

--- a/IdentitySdkCore/Podfile
+++ b/IdentitySdkCore/Podfile
@@ -14,6 +14,7 @@ target 'IdentitySdkCore' do
   pod 'EllipticCurveKeyPair', '~> 2.0'
   pod 'KeychainAccess', '~> 4.2.1'
   pod 'PromiseKit', '~> 6.13.1'
+  pod 'WebAuthnKit', '~> 0.9.6'
   pod "CryptoSwift", "~> 1.3.8"
 
 

--- a/IdentitySdkCore/Podfile.lock
+++ b/IdentitySdkCore/Podfile.lock
@@ -13,6 +13,11 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.13.1):
     - PromiseKit/CorePromise
+  - WebAuthnKit (0.9.6):
+    - CryptoSwift (~> 1.3.8)
+    - EllipticCurveKeyPair (~> 2.0)
+    - KeychainAccess (~> 4.2.1)
+    - PromiseKit (~> 6.13.1)
 
 DEPENDENCIES:
   - Alamofire (~> 5.6.1)
@@ -21,6 +26,7 @@ DEPENDENCIES:
   - EllipticCurveKeyPair (~> 2.0)
   - KeychainAccess (~> 4.2.1)
   - PromiseKit (~> 6.13.1)
+  - WebAuthnKit (~> 0.9.6)
 
 SPEC REPOS:
   trunk:
@@ -30,6 +36,7 @@ SPEC REPOS:
     - EllipticCurveKeyPair
     - KeychainAccess
     - PromiseKit
+    - WebAuthnKit
 
 SPEC CHECKSUMS:
   Alamofire: 87bd8c952f9a4454320fce00d9cc3de57bcadaf5
@@ -38,7 +45,8 @@ SPEC CHECKSUMS:
   EllipticCurveKeyPair: 8c69e5238a6e47243a10a48fbd41dfb19110b22e
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   PromiseKit: 28fda91c973cc377875d8c0ea4f973013c05b6db
+  WebAuthnKit: b778fee9d900b6b2697fbcac1e95b4609356801d
 
-PODFILE CHECKSUM: e441a8b34e7a5ed4f16795390a962d49d174caa4
+PODFILE CHECKSUM: 6b85935b68564269a21160390d2ec21280a34515
 
 COCOAPODS: 1.11.3

--- a/IdentitySdkFacebook/Podfile.lock
+++ b/IdentitySdkFacebook/Podfile.lock
@@ -20,6 +20,7 @@ PODS:
     - EllipticCurveKeyPair (~> 2.0)
     - KeychainAccess (~> 4.2.1)
     - PromiseKit (~> 6.13.1)
+    - WebAuthnKit (~> 0.9.6)
   - KeychainAccess (4.2.2)
   - PromiseKit (6.13.1):
     - PromiseKit/CorePromise (= 6.13.1)
@@ -30,6 +31,11 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.13.1):
     - PromiseKit/CorePromise
+  - WebAuthnKit (0.9.6):
+    - CryptoSwift (~> 1.3.8)
+    - EllipticCurveKeyPair (~> 2.0)
+    - KeychainAccess (~> 4.2.1)
+    - PromiseKit (~> 6.13.1)
 
 DEPENDENCIES:
   - FBSDKCoreKit (~> 9.0.0)
@@ -46,6 +52,7 @@ SPEC REPOS:
     - FBSDKLoginKit
     - KeychainAccess
     - PromiseKit
+    - WebAuthnKit
 
 EXTERNAL SOURCES:
   IdentitySdkCore:
@@ -58,9 +65,10 @@ SPEC CHECKSUMS:
   EllipticCurveKeyPair: 8c69e5238a6e47243a10a48fbd41dfb19110b22e
   FBSDKCoreKit: fada1a6a0076724678993ff05a633848765ff18c
   FBSDKLoginKit: d5ffe6d808897019ccf16feb6f0a7ab260bc5cd6
-  IdentitySdkCore: 1b5c645de6268c41aaeccc415e572588d68c9ac8
+  IdentitySdkCore: b5cbb4853a0504347b024e66dad78567e0ba3e7d
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   PromiseKit: 28fda91c973cc377875d8c0ea4f973013c05b6db
+  WebAuthnKit: b778fee9d900b6b2697fbcac1e95b4609356801d
 
 PODFILE CHECKSUM: 2e21448ce19d16d99399070e4b07396ef3eb47b4
 

--- a/IdentitySdkGoogle/Podfile.lock
+++ b/IdentitySdkGoogle/Podfile.lock
@@ -24,6 +24,7 @@ PODS:
     - EllipticCurveKeyPair (~> 2.0)
     - KeychainAccess (~> 4.2.1)
     - PromiseKit (~> 6.13.1)
+    - WebAuthnKit (~> 0.9.6)
   - KeychainAccess (4.2.2)
   - PromiseKit (6.13.1):
     - PromiseKit/CorePromise (= 6.13.1)
@@ -34,6 +35,11 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.13.1):
     - PromiseKit/CorePromise
+  - WebAuthnKit (0.9.6):
+    - CryptoSwift (~> 1.3.8)
+    - EllipticCurveKeyPair (~> 2.0)
+    - KeychainAccess (~> 4.2.1)
+    - PromiseKit (~> 6.13.1)
 
 DEPENDENCIES:
   - GoogleSignIn (~> 5)
@@ -51,6 +57,7 @@ SPEC REPOS:
     - GTMSessionFetcher
     - KeychainAccess
     - PromiseKit
+    - WebAuthnKit
 
 EXTERNAL SOURCES:
   IdentitySdkCore:
@@ -65,9 +72,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: 4d8f864896f3646f0c33baf38a28362f4c601e15
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  IdentitySdkCore: 1b5c645de6268c41aaeccc415e572588d68c9ac8
+  IdentitySdkCore: b5cbb4853a0504347b024e66dad78567e0ba3e7d
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   PromiseKit: 28fda91c973cc377875d8c0ea4f973013c05b6db
+  WebAuthnKit: b778fee9d900b6b2697fbcac1e95b4609356801d
 
 PODFILE CHECKSUM: 68a84dcaa4c5487281ef5c34c638857b5c7e658d
 

--- a/IdentitySdkWebView/Podfile.lock
+++ b/IdentitySdkWebView/Podfile.lock
@@ -10,6 +10,7 @@ PODS:
     - EllipticCurveKeyPair (~> 2.0)
     - KeychainAccess (~> 4.2.1)
     - PromiseKit (~> 6.13.1)
+    - WebAuthnKit (~> 0.9.6)
   - KeychainAccess (4.2.2)
   - PromiseKit (6.13.1):
     - PromiseKit/CorePromise (= 6.13.1)
@@ -20,6 +21,11 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.13.1):
     - PromiseKit/CorePromise
+  - WebAuthnKit (0.9.6):
+    - CryptoSwift (~> 1.3.8)
+    - EllipticCurveKeyPair (~> 2.0)
+    - KeychainAccess (~> 4.2.1)
+    - PromiseKit (~> 6.13.1)
 
 DEPENDENCIES:
   - IdentitySdkCore (from `../IdentitySdkCore.podspec`)
@@ -32,6 +38,7 @@ SPEC REPOS:
     - EllipticCurveKeyPair
     - KeychainAccess
     - PromiseKit
+    - WebAuthnKit
 
 EXTERNAL SOURCES:
   IdentitySdkCore:
@@ -42,9 +49,10 @@ SPEC CHECKSUMS:
   BrightFutures: 6a974d08b121658dc0e6b93f5dec5353f9c24a44
   CryptoSwift: 01b0f0cba1d5c212e5a335ff6c054fb75a204f00
   EllipticCurveKeyPair: 8c69e5238a6e47243a10a48fbd41dfb19110b22e
-  IdentitySdkCore: 1b5c645de6268c41aaeccc415e572588d68c9ac8
+  IdentitySdkCore: b5cbb4853a0504347b024e66dad78567e0ba3e7d
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   PromiseKit: 28fda91c973cc377875d8c0ea4f973013c05b6db
+  WebAuthnKit: b778fee9d900b6b2697fbcac1e95b4609356801d
 
 PODFILE CHECKSUM: e63fcb4c65d9d34c1639c962bd3416000e26c98d
 

--- a/Sandbox/Podfile.lock
+++ b/Sandbox/Podfile.lock
@@ -40,6 +40,7 @@ PODS:
     - EllipticCurveKeyPair (~> 2.0)
     - KeychainAccess (~> 4.2.1)
     - PromiseKit (~> 6.13.1)
+    - WebAuthnKit (~> 0.9.6)
   - IdentitySdkFacebook (5.6.2):
     - FacebookCore
     - FacebookLogin
@@ -59,6 +60,11 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.13.1):
     - PromiseKit/CorePromise
+  - WebAuthnKit (0.9.6):
+    - CryptoSwift (~> 1.3.8)
+    - EllipticCurveKeyPair (~> 2.0)
+    - KeychainAccess (~> 4.2.1)
+    - PromiseKit (~> 6.13.1)
 
 DEPENDENCIES:
   - IdentitySdkCore (from `../IdentitySdkCore.podspec`)
@@ -82,6 +88,7 @@ SPEC REPOS:
     - GTMSessionFetcher
     - KeychainAccess
     - PromiseKit
+    - WebAuthnKit
 
 EXTERNAL SOURCES:
   IdentitySdkCore:
@@ -106,12 +113,13 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: 4d8f864896f3646f0c33baf38a28362f4c601e15
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  IdentitySdkCore: 1b5c645de6268c41aaeccc415e572588d68c9ac8
+  IdentitySdkCore: b5cbb4853a0504347b024e66dad78567e0ba3e7d
   IdentitySdkFacebook: bc3f609c82c8f9572cbaaf018cac675c8eb85e7a
   IdentitySdkGoogle: 214587ef01405540c3cbfa5a24a9dcb2b8eed718
   IdentitySdkWebView: cf61268a7e43a150cee534ca08ad44d2c934b914
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   PromiseKit: 28fda91c973cc377875d8c0ea4f973013c05b6db
+  WebAuthnKit: b778fee9d900b6b2697fbcac1e95b4609356801d
 
 PODFILE CHECKSUM: df5646bc517f22e8e98863ab8a2bdb1e3e4b11c2
 


### PR DESCRIPTION
Reintroducing `WebAuthnKit` 0.9.6.
Of course do not merge until we decide what to do with `WebAuthnKit`:
- "Make" the maintainer update the lib
- fork the repo to update to Swift 5
- integrate the useful parts of the lib into the SDK
- drop it completely and rewrite the integration in another way