### PR TITLE
[CA-1530] Mise à jour de Facebook vers v14

### DIFF
--- a/IdentitySdkCore/IdentitySdkCore/Classes/Provider.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/Provider.swift
@@ -12,6 +12,7 @@ public protocol Provider {
     func login(scope: [String]?, origin: String, viewController: UIViewController?) -> Future<AuthToken, ReachFiveError>
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool
     func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
     func applicationDidBecomeActive(_ application: UIApplication)
     func logout() -> Future<(), ReachFiveError>
 }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveProviders.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveProviders.swift
@@ -69,6 +69,16 @@ public extension ReachFive {
         return true
     }
     
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        initialize().map { providers in
+            for provider in providers {
+                let _ = provider.application(application, didFinishLaunchingWithOptions: launchOptions)
+            }
+        }
+        
+        return true
+    }
+    
     func applicationDidBecomeActive(_ application: UIApplication) {
         for provider in providers {
             let _ = provider.applicationDidBecomeActive(application)

--- a/IdentitySdkFacebook.podspec
+++ b/IdentitySdkFacebook.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = $IOS_DEPLOYMENT_TARGET
 
   spec.dependency 'IdentitySdkCore', '~> 5'
-  spec.dependency 'FacebookCore'
-  spec.dependency 'FacebookLogin'
+  spec.dependency 'FBSDKCoreKit', '~> 13'
+  spec.dependency 'FBSDKLoginKit', '~> 13'
 end

--- a/IdentitySdkFacebook.podspec
+++ b/IdentitySdkFacebook.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = $IOS_DEPLOYMENT_TARGET
 
   spec.dependency 'IdentitySdkCore', '~> 5'
-  spec.dependency 'FBSDKCoreKit', '~> 13'
-  spec.dependency 'FBSDKLoginKit', '~> 13'
+  spec.dependency 'FBSDKCoreKit', '~> 14.1.0'
+  spec.dependency 'FBSDKLoginKit', '~> 14.1.0'
 end

--- a/IdentitySdkFacebook/IdentitySdkFacebook/Classes/FacebookProvider.swift
+++ b/IdentitySdkFacebook/IdentitySdkFacebook/Classes/FacebookProvider.swift
@@ -2,8 +2,6 @@ import Foundation
 import UIKit
 import IdentitySdkCore
 import BrightFutures
-import FacebookCore
-import FacebookLogin
 import FBSDKLoginKit
 
 public class FacebookProvider: ProviderCreator {
@@ -64,7 +62,7 @@ public class ConfiguredFacebookProvider: NSObject, Provider {
             case .success(_, _, let token):
                 let loginProviderRequest = LoginProviderRequest(
                     provider: self.providerConfig.provider,
-                    providerToken: token.tokenString,
+                    providerToken: token?.tokenString,
                     code: nil,
                     origin: origin,
                     clientId: self.sdkConfig.clientId,
@@ -99,7 +97,7 @@ public class ConfiguredFacebookProvider: NSObject, Provider {
     }
     
     public func applicationDidBecomeActive(_ application: UIApplication) {
-        AppEvents.activateApp()
+        AppEvents.shared.activateApp()
     }
     
     public func logout() -> Future<(), ReachFiveError> {

--- a/IdentitySdkFacebook/IdentitySdkFacebook/Classes/FacebookProvider.swift
+++ b/IdentitySdkFacebook/IdentitySdkFacebook/Classes/FacebookProvider.swift
@@ -64,7 +64,7 @@ public class ConfiguredFacebookProvider: NSObject, Provider {
         }
         
         let promise = Promise<AuthToken, ReachFiveError>()
-        LoginManager().logIn(permissions: ["email", "public_profile"], from: viewController) { (result, error) in
+        LoginManager().logIn(permissions: providerConfig.scope ?? ["email", "public_profile"], from: viewController) { (result, error) in
             guard let result = result else {
                 let reason = error == nil ? "No result" : error!.localizedDescription
                 promise.failure(.TechnicalError(reason: reason))

--- a/IdentitySdkFacebook/IdentitySdkFacebook/Classes/FacebookProvider.swift
+++ b/IdentitySdkFacebook/IdentitySdkFacebook/Classes/FacebookProvider.swift
@@ -103,6 +103,10 @@ public class ConfiguredFacebookProvider: NSObject, Provider {
         FBSDKCoreKit.ApplicationDelegate.shared.application(app, open: url, options: options)
     }
     
+    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        FBSDKCoreKit.ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+    
     public func applicationDidBecomeActive(_ application: UIApplication) {
         AppEvents.shared.activateApp()
     }

--- a/IdentitySdkFacebook/Podfile
+++ b/IdentitySdkFacebook/Podfile
@@ -4,6 +4,6 @@ platform :ios, '13.0'
 
 target 'IdentitySdkFacebook' do
   pod 'IdentitySdkCore', :path => '../IdentitySdkCore.podspec'
-  pod 'FBSDKCoreKit', '~> 9.0.0'
-  pod 'FBSDKLoginKit', '~> 9.0.0'
+  pod 'FBSDKCoreKit', '~> 13'
+  pod 'FBSDKLoginKit', '~> 13'
 end

--- a/IdentitySdkFacebook/Podfile
+++ b/IdentitySdkFacebook/Podfile
@@ -4,6 +4,6 @@ platform :ios, '13.0'
 
 target 'IdentitySdkFacebook' do
   pod 'IdentitySdkCore', :path => '../IdentitySdkCore.podspec'
-  pod 'FBSDKCoreKit', '~> 13'
-  pod 'FBSDKLoginKit', '~> 13'
+  pod 'FBSDKCoreKit', '~> 14.1.0'
+  pod 'FBSDKLoginKit', '~> 14.1.0'
 end

--- a/IdentitySdkFacebook/Podfile.lock
+++ b/IdentitySdkFacebook/Podfile.lock
@@ -3,16 +3,14 @@ PODS:
   - BrightFutures (8.2.0)
   - CryptoSwift (1.5.1)
   - EllipticCurveKeyPair (2.0)
-  - FBSDKCoreKit (9.0.1):
-    - FBSDKCoreKit/Basics (= 9.0.1)
-    - FBSDKCoreKit/Core (= 9.0.1)
-  - FBSDKCoreKit/Basics (9.0.1)
-  - FBSDKCoreKit/Core (9.0.1):
-    - FBSDKCoreKit/Basics
-  - FBSDKLoginKit (9.0.1):
-    - FBSDKLoginKit/Login (= 9.0.1)
-  - FBSDKLoginKit/Login (9.0.1):
-    - FBSDKCoreKit (~> 9.0.1)
+  - FBAEMKit (14.1.0):
+    - FBSDKCoreKit_Basics (= 14.1.0)
+  - FBSDKCoreKit (14.1.0):
+    - FBAEMKit (= 14.1.0)
+    - FBSDKCoreKit_Basics (= 14.1.0)
+  - FBSDKCoreKit_Basics (14.1.0)
+  - FBSDKLoginKit (14.1.0):
+    - FBSDKCoreKit (= 14.1.0)
   - IdentitySdkCore (5.6.2):
     - Alamofire (~> 5.6.1)
     - BrightFutures (~> 8.2.0)
@@ -32,8 +30,8 @@ PODS:
     - PromiseKit/CorePromise
 
 DEPENDENCIES:
-  - FBSDKCoreKit (~> 9.0.0)
-  - FBSDKLoginKit (~> 9.0.0)
+  - FBSDKCoreKit (~> 14.1.0)
+  - FBSDKLoginKit (~> 14.1.0)
   - IdentitySdkCore (from `../IdentitySdkCore.podspec`)
 
 SPEC REPOS:
@@ -42,7 +40,9 @@ SPEC REPOS:
     - BrightFutures
     - CryptoSwift
     - EllipticCurveKeyPair
+    - FBAEMKit
     - FBSDKCoreKit
+    - FBSDKCoreKit_Basics
     - FBSDKLoginKit
     - KeychainAccess
     - PromiseKit
@@ -56,12 +56,14 @@ SPEC CHECKSUMS:
   BrightFutures: 67e0e8cd974ab9f6c04650cc64153f7adf1ec489
   CryptoSwift: c4f2debceb38bf44c80659afe009f71e23e4a082
   EllipticCurveKeyPair: 8c69e5238a6e47243a10a48fbd41dfb19110b22e
-  FBSDKCoreKit: fada1a6a0076724678993ff05a633848765ff18c
-  FBSDKLoginKit: d5ffe6d808897019ccf16feb6f0a7ab260bc5cd6
-  IdentitySdkCore: 220a84190a749587cebe10496b090ec3dacebb6d
+  FBAEMKit: a899515e45476027f73aef377b5cffadcd56ca3a
+  FBSDKCoreKit: 24f8bc8d3b5b2a8c5c656a1329492a12e8efa792
+  FBSDKCoreKit_Basics: 6e578c9bdc7aa1365dbbbde633c9ebb536bcaa98
+  FBSDKLoginKit: 787de205d524c3a4b17d527916f1d066e4361660
+  IdentitySdkCore: 1105ab28e5598697e1beefe50143cbcbae63ba90
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   PromiseKit: 879fa89b55fcb8f11ade9aad0c9721850bb71b9f
 
-PODFILE CHECKSUM: 7b453b84a744bc5f3cbb7d5fa9af064693eb5aec
+PODFILE CHECKSUM: 517c34edf936aa6a7bc0f128f942622ed455768e
 
 COCOAPODS: 1.11.3

--- a/IdentitySdkGoogle/IdentitySdkGoogle/Classes/GoogleProvider.swift
+++ b/IdentitySdkGoogle/IdentitySdkGoogle/Classes/GoogleProvider.swift
@@ -99,6 +99,10 @@ public class ConfiguredGoogleProvider: NSObject, Provider, GIDSignInDelegate {
         return GIDSignIn.sharedInstance().handle(url)
     }
     
+    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        true
+    }
+    
     public func applicationDidBecomeActive(_ application: UIApplication) {}
     
     public func logout() -> Future<(), ReachFiveError> {

--- a/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
+++ b/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
@@ -133,6 +133,10 @@ class ConfiguredWebViewProvider: NSObject, Provider, SFSafariViewControllerDeleg
         true
     }
     
+    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        true
+    }
+    
     public func applicationDidBecomeActive(_ application: UIApplication) {
         
     }

--- a/Sandbox/Podfile.lock
+++ b/Sandbox/Podfile.lock
@@ -9,22 +9,14 @@ PODS:
   - BrightFutures (8.2.0)
   - CryptoSwift (1.5.1)
   - EllipticCurveKeyPair (2.0)
-  - FacebookCore (0.9.0):
-    - FBSDKCoreKit (~> 5.0)
-  - FacebookLogin (0.9.0):
-    - FacebookCore (~> 0.9.0)
-    - FBSDKCoreKit (~> 5.0)
-    - FBSDKLoginKit (~> 5.0)
-  - FBSDKCoreKit (5.15.1):
-    - FBSDKCoreKit/Basics (= 5.15.1)
-    - FBSDKCoreKit/Core (= 5.15.1)
-  - FBSDKCoreKit/Basics (5.15.1)
-  - FBSDKCoreKit/Core (5.15.1):
-    - FBSDKCoreKit/Basics
-  - FBSDKLoginKit (5.15.1):
-    - FBSDKLoginKit/Login (= 5.15.1)
-  - FBSDKLoginKit/Login (5.15.1):
-    - FBSDKCoreKit (~> 5.0)
+  - FBAEMKit (14.1.0):
+    - FBSDKCoreKit_Basics (= 14.1.0)
+  - FBSDKCoreKit (14.1.0):
+    - FBAEMKit (= 14.1.0)
+    - FBSDKCoreKit_Basics (= 14.1.0)
+  - FBSDKCoreKit_Basics (14.1.0)
+  - FBSDKLoginKit (14.1.0):
+    - FBSDKCoreKit (= 14.1.0)
   - GoogleSignIn (5.0.2):
     - AppAuth (~> 1.2)
     - GTMAppAuth (~> 1.0)
@@ -41,8 +33,8 @@ PODS:
     - KeychainAccess (~> 4.2.1)
     - PromiseKit (~> 6.18.0)
   - IdentitySdkFacebook (5.6.2):
-    - FacebookCore
-    - FacebookLogin
+    - FBSDKCoreKit (~> 14.1.0)
+    - FBSDKLoginKit (~> 14.1.0)
     - IdentitySdkCore (~> 5)
   - IdentitySdkGoogle (5.6.2):
     - GoogleSignIn (~> 5)
@@ -73,9 +65,9 @@ SPEC REPOS:
     - BrightFutures
     - CryptoSwift
     - EllipticCurveKeyPair
-    - FacebookCore
-    - FacebookLogin
+    - FBAEMKit
     - FBSDKCoreKit
+    - FBSDKCoreKit_Basics
     - FBSDKLoginKit
     - GoogleSignIn
     - GTMAppAuth
@@ -99,10 +91,10 @@ SPEC CHECKSUMS:
   BrightFutures: 67e0e8cd974ab9f6c04650cc64153f7adf1ec489
   CryptoSwift: c4f2debceb38bf44c80659afe009f71e23e4a082
   EllipticCurveKeyPair: 8c69e5238a6e47243a10a48fbd41dfb19110b22e
-  FacebookCore: ba86524b66cfa86d0f8e65d08faa8504a9f732dd
-  FacebookLogin: 6cee9fd6e1fe976fe8f7eec199e27b28b14f5d63
-  FBSDKCoreKit: 1d5acf7c9d7a2f92bb1a242dc60cae5b7adb91df
-  FBSDKLoginKit: f1ea8026a58b52d30c9f2e6a58ca7d813619fb83
+  FBAEMKit: a899515e45476027f73aef377b5cffadcd56ca3a
+  FBSDKCoreKit: 24f8bc8d3b5b2a8c5c656a1329492a12e8efa792
+  FBSDKCoreKit_Basics: 6e578c9bdc7aa1365dbbbde633c9ebb536bcaa98
+  FBSDKLoginKit: 787de205d524c3a4b17d527916f1d066e4361660
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: 4d8f864896f3646f0c33baf38a28362f4c601e15
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba

--- a/Sandbox/Sandbox.xcodeproj/project.pbxproj
+++ b/Sandbox/Sandbox.xcodeproj/project.pbxproj
@@ -450,8 +450,6 @@
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/CryptoSwift\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/FBSDKCoreKit\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/FBSDKLoginKit\"",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/FacebookCore\"",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/FacebookLogin\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/GTMSessionFetcher\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleToolboxForMac\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/IdentitySdkCore\"",

--- a/Sandbox/Sandbox/AppDelegate.swift
+++ b/Sandbox/Sandbox/AppDelegate.swift
@@ -3,7 +3,6 @@ import IdentitySdkCore
 import IdentitySdkFacebook
 import IdentitySdkWebView
 import IdentitySdkGoogle
-import FBSDKCoreKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -53,10 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("addPasswordlessCallback \(result)")
         }
         
-        // Initialize Facebook SDK
-        FBSDKCoreKit.ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
-
-        return true
+        return reachfive.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {

--- a/Sandbox/Sandbox/AppDelegate.swift
+++ b/Sandbox/Sandbox/AppDelegate.swift
@@ -3,6 +3,7 @@ import IdentitySdkCore
 import IdentitySdkFacebook
 import IdentitySdkWebView
 import IdentitySdkGoogle
+import FBSDKCoreKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -52,6 +53,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("addPasswordlessCallback \(result)")
         }
         
+        // Initialize Facebook SDK
+        FBSDKCoreKit.ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
+
         return true
     }
     

--- a/Sandbox/Sandbox/Info.plist
+++ b/Sandbox/Sandbox/Info.plist
@@ -53,6 +53,8 @@
 	<string>1</string>
 	<key>FacebookAppID</key>
 	<string>1634029666893228</string>
+	<key>FacebookClientToken</key>
+	<string>1a774a90e2e5ec97b21afcd93ce69909</string>
 	<key>FacebookDisplayName</key>
 	<string>Reach5 SDK Mobile</string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
[Jira](https://reach5.atlassian.net/browse/CA-1530)

Apporte une amélioration : si l'utilisateur a toujours un token d'authentification valide, on n'ouvre pas la webview de connexion.

Cette mise à jour apporte des changements incompatibles listés dans le ticket.