### PR TITLE
[CA-1533] Utiliser ASWebAuthenticationSession dans le SDK Webview

### DIFF
--- a/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
+++ b/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
@@ -2,6 +2,7 @@ import Foundation
 import SafariServices
 import IdentitySdkCore
 import BrightFutures
+import AuthenticationServices
 
 public class WebViewProvider: ProviderCreator {
     public static let NAME = "webview"
@@ -26,11 +27,6 @@ public class WebViewProvider: ProviderCreator {
 }
 
 class ConfiguredWebViewProvider: NSObject, Provider, SFSafariViewControllerDelegate {
-    private let notificationName = Notification.Name("AuthCallbackNotification")
-    private var safariViewController: SFSafariViewController? = nil
-    private var pkce: Pkce = Pkce.generate()
-    private var promise: Promise<AuthToken, ReachFiveError>?
-    
     var name: String = WebViewProvider.NAME
     
     let sdkConfig: SdkConfig
@@ -56,11 +52,8 @@ class ConfiguredWebViewProvider: NSObject, Provider, SFSafariViewControllerDeleg
         origin: String,
         viewController: UIViewController?
     ) -> Future<AuthToken, ReachFiveError> {
-        promise?.tryFailure(.AuthCanceled)
         let promise = Promise<AuthToken, ReachFiveError>()
-        self.promise = promise
-        pkce = Pkce.generate()
-        UserDefaultsStorage().save(key: "PASSWORDLESS_PKCE", value: pkce)
+        let pkce = Pkce.generate()
         let url = buildUrl(
             sdkConfig: sdkConfig,
             providerConfig: providerConfig,
@@ -68,65 +61,61 @@ class ConfiguredWebViewProvider: NSObject, Provider, SFSafariViewControllerDeleg
             pkce: pkce
         )
         
-        NotificationCenter.default.addObserver(self, selector: #selector(handleLogin(_:)), name: notificationName, object: nil)
+        guard let authURL = URL(string: url) else {
+            promise.failure(.TechnicalError(reason: "Cannot build authorize URL"))
+            return promise.future
+        }
         
-        safariViewController = SFSafariViewController.init(url: URL(string: url)!)
+        let session = ASWebAuthenticationSession(url: authURL, callbackURLScheme: "reachfive-\(sdkConfig.clientId)") { callbackURL, error in
+            guard error == nil else {
+                let r5Error: ReachFiveError
+                switch error!._code {
+                case 1: r5Error = .AuthCanceled
+                case 2: r5Error = .TechnicalError(reason: "Presentation Context Not Provided")
+                case 3: r5Error = .TechnicalError(reason: "Presentation Context Invalid")
+                default:
+                    r5Error = .TechnicalError(reason: "Unknown Error")
+                }
+                promise.failure(r5Error)
+                return
+            }
+            
+            guard let callbackURL = callbackURL else {
+                promise.failure(.TechnicalError(reason: "No callback URL"))
+                return
+            }
+            
+            let queryItems = URLComponents(string: callbackURL.absoluteString)?.queryItems
+            let code = queryItems?.first(where: { $0.name == "code" })?.value
+            guard let code = code else {
+                promise.failure(.TechnicalError(reason: "No authorization code"))
+                return
+            }
+            
+            promise.completeWith(self.handleAuthCode(code: code, pkce: pkce))
+        }
         
-        viewController?.present(safariViewController!, animated: true)
+        // Set an appropriate context provider instance that determines the window that acts as a presentation anchor for the session
+        session.presentationContextProvider = (viewController! as! ASWebAuthenticationPresentationContextProviding)
+        
+        // Start the Authentication Flow
+        session.start()
         return promise.future
     }
     
-    @objc func handleLogin(_ notification: Notification) {
-        NotificationCenter.default.removeObserver(self, name: notificationName, object: nil)
-        
-        let url = notification.object as? URL
-        
-        if let query = url?.query {
-            let params = QueryString.parseQueriesStrings(query: query)
-            let code = params["code"]
-            if code != nil {
-                handleAuthCode(code!!)
-            } else {
-                promise?.failure(.TechnicalError(reason: "No authorization code"))
-            }
-        } else {
-            promise?.failure(.TechnicalError(reason: "No authorization code"))
-        }
-        
-        safariViewController?.dismiss(animated: true, completion: nil)
-    }
-    
-    private func handleAuthCode(_ code: String) {
+    private func handleAuthCode(code: String, pkce: Pkce) -> Future<AuthToken, ReachFiveError> {
         let authCodeRequest = AuthCodeRequest(
             clientId: sdkConfig.clientId,
             code: code,
             redirectUri: sdkConfig.scheme,
             pkce: pkce
         )
-        reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)
+        return reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)
             .flatMap({ AuthToken.fromOpenIdTokenResponseFuture($0) })
-            .onSuccess { authToken in
-                self.promise?.success(authToken)
-            }
-            .onFailure { error in
-                self.promise?.failure(error)
-            }
-    }
-    
-    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        NotificationCenter.default.removeObserver(self, name: notificationName, object: nil)
-        controller.dismiss(animated: true, completion: nil)
     }
     
     public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-        if let sourceApplication = options[.sourceApplication] {
-            if (String(describing: sourceApplication) == "com.apple.SafariViewService") {
-                NotificationCenter.default.post(name: notificationName, object: url)
-                return true
-            }
-        }
-        
-        return false
+        true
     }
     
     func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
@@ -138,11 +127,10 @@ class ConfiguredWebViewProvider: NSObject, Provider, SFSafariViewControllerDeleg
     }
     
     public func applicationDidBecomeActive(_ application: UIApplication) {
-        
     }
     
     public func logout() -> Future<(), ReachFiveError> {
-        Future.init(value: ())
+        Future(value: ())
     }
     
     func buildUrl(sdkConfig: SdkConfig, providerConfig: ProviderConfig, scope: String, pkce: Pkce) -> String {

--- a/Sandbox/Sandbox/LoginWithProvidersController.swift
+++ b/Sandbox/Sandbox/LoginWithProvidersController.swift
@@ -1,8 +1,9 @@
 import UIKit
 import IdentitySdkCore
 import GoogleSignIn
+import AuthenticationServices
 
-class LoginWithProvidersController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+class LoginWithProvidersController: UIViewController, UITableViewDataSource, UITableViewDelegate, ASWebAuthenticationPresentationContextProviding {
     var providers: [Provider] = []
     
     @IBOutlet weak var providersTableView: UITableView!
@@ -80,5 +81,9 @@ class LoginWithProvidersController: UIViewController, UITableViewDataSource, UIT
     
     func numberOfSections(in tableView: UITableView) -> Int {
         1
+    }
+    
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        view.window!
     }
 }


### PR DESCRIPTION
[[iOS] Migrer les Webview d'authentification vers `ASWebAuthenticationSession`](https://reach5.atlassian.net/browse/CA-1533)

Aussi, deux changement incompatibles : 
- Rend le paramètre viewController obligatoire dans `Provider.login`
- ce paramèter doit en fait être un `ASWebAuthenticationPresentationContextProviding` dans `WebViewProvider`