### PR TITLE
Meilleure gestion des erreurs dans les callback 

### DIFF
--- a/IdentitySdkCore/IdentitySdkCore/Classes/LoginWKWebview.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/LoginWKWebview.swift
@@ -44,7 +44,7 @@ extension LoginWKWebview: WKNavigationDelegate {
         decisionHandler(.cancel)
         let params = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems
         guard let params, let code = params.first(where: { $0.name == "code" })?.value else {
-            promise.failure(.TechnicalError(reason: "No authorization code"))
+            promise.failure(.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params)))
             return
         }
         

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveApi.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveApi.swift
@@ -134,10 +134,10 @@ public class ReachFiveApi {
                     promise.failure(.TechnicalError(reason: "No location"))
                     return
                 }
-                let queryItems = URLComponents(string: callbackURL)?.queryItems
-                let code = queryItems?.first(where: { $0.name == "code" })?.value
+                let params = URLComponents(string: callbackURL)?.queryItems
+                let code = params?.first(where: { $0.name == "code" })?.value
                 guard let code else {
-                    promise.failure(.TechnicalError(reason: "No authorization code"))
+                    promise.failure(.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params)))
                     return
                 }
                 promise.success(code)

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveError.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveError.swift
@@ -111,7 +111,7 @@ public class ApiError: Codable, CustomStringConvertible {
             errorId: errorId,
             errorUserMsg: userMsg,
             errorMessageKey: key,
-            errorDescription: desc.map { s in s.replacingOccurrences(of: "+", with: " ") }
+            errorDescription: desc?.replacingOccurrences(of: "+", with: " ")
         )
     }
 }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveError.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveError.swift
@@ -31,7 +31,7 @@ public enum ReachFiveError: Error, CustomStringConvertible {
     
     private func createMessage(reason: String, apiError: ApiError? = nil) -> String {
         let allMessages: String? = apiError.flatMap { error in
-            let topLevelMessage = error.errorUserMsg
+            let topLevelMessage = error.errorUserMsg ?? error.errorDescription
             var fieldMessages = error.errorDetails.flatMap { fieldErrors in fieldErrors.compactMap { $0.message } } ?? []
             
             if let topLevelMessage {
@@ -48,7 +48,7 @@ public enum ReachFiveError: Error, CustomStringConvertible {
         if reason.isEmpty {
             return allMessages ?? "no message"
         } else {
-            return allMessages.map { m in "\(reason): \(m)" } ?? reason
+            return allMessages.map { m in "\(reason)\n \(m)" } ?? reason
         }
     }
     
@@ -63,8 +63,10 @@ public enum ReachFiveError: Error, CustomStringConvertible {
 public class ApiError: Codable, CustomStringConvertible {
     public var description: String {
         mkString(start: "ApiError", fields: (error, "error"),
+            (errorId, "errorId"),
             (errorMessageKey, "errorMessageKey"),
             (errorUserMsg, "errorUserMsg"),
+            (errorDescription, "errorDescription"),
             (errorDetails, "errorDetails"))
     }
     
@@ -74,6 +76,20 @@ public class ApiError: Codable, CustomStringConvertible {
     public let errorMessageKey: String?
     public let errorDescription: String?
     public let errorDetails: [FieldError]?
+    
+    public init(error: String? = nil,
+                errorId: String? = nil,
+                errorUserMsg: String? = nil,
+                errorMessageKey: String? = nil,
+                errorDescription: String? = nil,
+                errorDetails: [FieldError]? = nil) {
+        self.error = error
+        self.errorId = errorId
+        self.errorUserMsg = errorUserMsg
+        self.errorMessageKey = errorMessageKey
+        self.errorDescription = errorDescription
+        self.errorDetails = errorDetails
+    }
 }
 
 public class FieldError: Codable, CustomStringConvertible {
@@ -86,4 +102,10 @@ public class FieldError: Codable, CustomStringConvertible {
     public let field: String?
     public let message: String?
     public let code: String?
+    
+    public init(field: String? = nil, message: String? = nil, code: String? = nil) {
+        self.field = field
+        self.message = message
+        self.code = code
+    }
 }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveError.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveError.swift
@@ -90,6 +90,30 @@ public class ApiError: Codable, CustomStringConvertible {
         self.errorDescription = errorDescription
         self.errorDetails = errorDetails
     }
+    
+    public convenience init?(fromQueryParams params: [URLQueryItem]?) {
+        guard let params else {
+            return nil
+        }
+        
+        let error = params.first(where: { $0.name == "error" })?.value
+        let errorId = params.first(where: { $0.name == "error_id" })?.value
+        let userMsg = params.first(where: { $0.name == "error_user_msg" })?.value
+        let key = params.first(where: { $0.name == "error_message_key" })?.value
+        let desc = params.first(where: { $0.name == "error_description" })?.value
+        
+        if (error == nil && errorId == nil && userMsg == nil && key == nil && desc == nil) {
+            return nil
+        }
+        
+        self.init(
+            error: error,
+            errorId: errorId,
+            errorUserMsg: userMsg,
+            errorMessageKey: key,
+            errorDescription: desc.map { s in s.replacingOccurrences(of: "+", with: " ") }
+        )
+    }
 }
 
 public class FieldError: Codable, CustomStringConvertible {

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFivePasswordLess.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFivePasswordLess.swift
@@ -74,19 +74,35 @@ public extension ReachFive {
             passwordlessCallback?(.failure(.TechnicalError(reason: "Pkce not found")))
             return
         }
-        if let params, let code = params.first(where: { $0.name == "code" })?.value {
-            let authCodeRequest = AuthCodeRequest(
-                clientId: sdkConfig.clientId,
-                code: code,
-                redirectUri: sdkConfig.scheme,
-                pkce: pkce
-            )
+        guard let params, let code = params.first(where: { $0.name == "code" })?.value else {
+            let error = params?.first(where: { $0.name == "error" })?.value
+            let errorId = params?.first(where: { $0.name == "error_id" })?.value
+            let userMsg = params?.first(where: { $0.name == "error_user_msg" })?.value
+            let key = params?.first(where: { $0.name == "error_message_key" })?.value
+            let desc = params?.first(where: { $0.name == "error_description" })?.value
             
-            reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)
-                .flatMap({ AuthToken.fromOpenIdTokenResponseFuture($0) })
-                .onComplete { result in
-                    self.passwordlessCallback?(result)
-                }
+            let apiError = ApiError(
+                error: error,
+                errorId: errorId,
+                errorUserMsg: userMsg,
+                errorMessageKey: key,
+                errorDescription: desc.map { s in s.replacingOccurrences(of: "+", with: " ") }
+            )
+            passwordlessCallback?(.failure(.TechnicalError(reason: "No authorization code", apiError: apiError)))
+            return
         }
+        
+        let authCodeRequest = AuthCodeRequest(
+            clientId: sdkConfig.clientId,
+            code: code,
+            redirectUri: sdkConfig.scheme,
+            pkce: pkce
+        )
+        
+        reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)
+            .flatMap({ AuthToken.fromOpenIdTokenResponseFuture($0) })
+            .onComplete { result in
+                self.passwordlessCallback?(result)
+            }
     }
 }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFivePasswordLess.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFivePasswordLess.swift
@@ -75,20 +75,7 @@ public extension ReachFive {
             return
         }
         guard let params, let code = params.first(where: { $0.name == "code" })?.value else {
-            let error = params?.first(where: { $0.name == "error" })?.value
-            let errorId = params?.first(where: { $0.name == "error_id" })?.value
-            let userMsg = params?.first(where: { $0.name == "error_user_msg" })?.value
-            let key = params?.first(where: { $0.name == "error_message_key" })?.value
-            let desc = params?.first(where: { $0.name == "error_description" })?.value
-            
-            let apiError = ApiError(
-                error: error,
-                errorId: errorId,
-                errorUserMsg: userMsg,
-                errorMessageKey: key,
-                errorDescription: desc.map { s in s.replacingOccurrences(of: "+", with: " ") }
-            )
-            passwordlessCallback?(.failure(.TechnicalError(reason: "No authorization code", apiError: apiError)))
+            passwordlessCallback?(.failure(.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params))))
             return
         }
         

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveWebviewLogin.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveWebviewLogin.swift
@@ -31,10 +31,9 @@ public extension ReachFive {
                 return
             }
             
-            let queryItems = URLComponents(url: callbackURL, resolvingAgainstBaseURL: true)?.queryItems
-            let code = queryItems?.first(where: { $0.name == "code" })?.value
-            guard let code else {
-                promise.failure(.TechnicalError(reason: "No authorization code"))
+            let params = URLComponents(url: callbackURL, resolvingAgainstBaseURL: true)?.queryItems
+            guard let params, let code = params.first(where: { $0.name == "code" })?.value else {
+                promise.failure(.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params)))
                 return
             }
             

--- a/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
+++ b/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
@@ -91,10 +91,10 @@ class ConfiguredWebViewProvider: NSObject, Provider {
                 return
             }
             
-            let queryItems = URLComponents(string: callbackURL.absoluteString)?.queryItems
-            let code = queryItems?.first(where: { $0.name == "code" })?.value
+            let params = URLComponents(url: callbackURL, resolvingAgainstBaseURL: true)?.queryItems
+            let code = params?.first(where: { $0.name == "code" })?.value
             guard let code else {
-                promise.failure(.TechnicalError(reason: "No authorization code"))
+                promise.failure(.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params)))
                 return
             }
             

--- a/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
+++ b/IdentitySdkWebView/IdentitySdkWebView/Classes/WebViewProvider.swift
@@ -73,9 +73,9 @@ class ConfiguredWebViewProvider: NSObject, Provider {
         }
         
         let session = ASWebAuthenticationSession(url: authURL, callbackURLScheme: sdkConfig.baseScheme) { callbackURL, error in
-            guard error == nil else {
+            if let error {
                 let r5Error: ReachFiveError
-                switch error!._code {
+                switch error._code {
                 case 1: r5Error = .AuthCanceled
                 case 2: r5Error = .TechnicalError(reason: "Presentation Context Not Provided")
                 case 3: r5Error = .TechnicalError(reason: "Presentation Context Invalid")

--- a/IdentitySdkWebView/Podfile
+++ b/IdentitySdkWebView/Podfile
@@ -3,6 +3,5 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'IdentitySdkWebView' do
-  inherit! :search_paths
   pod 'IdentitySdkCore', :path => '../IdentitySdkCore.podspec'
 end

--- a/IdentitySdkWebView/Podfile
+++ b/IdentitySdkWebView/Podfile
@@ -3,5 +3,6 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'IdentitySdkWebView' do
+  inherit! :search_paths
   pod 'IdentitySdkCore', :path => '../IdentitySdkCore.podspec'
 end

--- a/Sandbox/Sandbox/LoginWithProvidersController.swift
+++ b/Sandbox/Sandbox/LoginWithProvidersController.swift
@@ -40,7 +40,6 @@ class LoginWithProvidersController: UIViewController, UITableViewDataSource, UIT
     func handleResult(result: Result<AuthToken, ReachFiveError>) {
         switch result {
         case .success(let authToken):
-            AppDelegate.storage.save(key: SecureStorage.authKey, value: authToken)
             goToProfile(authToken)
         case .failure(let error):
             print(error)

--- a/Sandbox/Sandbox/PasswordlessController.swift
+++ b/Sandbox/Sandbox/PasswordlessController.swift
@@ -9,6 +9,23 @@ class PasswordlessController: UIViewController {
     @IBOutlet weak var phoneNumberInput: UITextField!
     @IBOutlet weak var verificationCodeInput: UITextField!
     
+    var tokenNotification: NSObjectProtocol?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { (note) in
+            if let result = note.userInfo?["result"], let result = result as? Result<AuthToken, ReachFiveError> {
+                switch result {
+                case .success(let authToken):
+                    self.goToProfile(authToken)
+                case .failure(let error):
+                    let alert = AppDelegate.createAlert(title: "Passwordless failed", message: "Error: \(error.message())")
+                    self.present(alert, animated: true)
+                }
+            }
+        }
+    }
+    
     @IBAction func loginWithEmail(_ sender: Any) {
         AppDelegate.reachfive()
             .startPasswordless(
@@ -59,16 +76,10 @@ class PasswordlessController: UIViewController {
         )
         AppDelegate.reachfive()
             .verifyPasswordlessCode(verifyAuthCodeRequest: verifyAuthCodeRequest)
-            .onSuccess { success in
-                let alert = AppDelegate.createAlert(title: "Verify code", message: "Success: \(success)")
-                self.present(alert, animated: true, completion: nil)
-            }
+            .onSuccess(callback: goToProfile)
             .onFailure { error in
                 let alert = AppDelegate.createAlert(title: "Verify code", message: "Error: \(error.message())")
-                self.present(alert, animated: true, completion: nil)
-            }
-            .onComplete { result in
-                print("verifyPasswordless \(result)")
+                self.present(alert, animated: true)
             }
     }
 }


### PR DESCRIPTION
Quand on reçoit une redirection via un scheme, s'il y a eu une erreur côté serveur, on va recevoir une erreur dans l'URL de ce type : 
```
reachfive-sg48cdayohrperwz9j1h://callback?error=invalid_grant&error_description=Code+de+v%C3%A9rification+invalide&error_message_key=error.invalidVerificationCode&state=passwordless
```

On est maintenant capable d'en extraire un objet d'erreur de ce type : 
```
ApiError(error: "invalid_grant", errorMessageKey: "error.invalidVerificationCode", errorDescription: "Code de vérification invalide")
```