### PR TITLE
[CA-3210] Ajout de l'origine pour les clés d'identification

### DIFF
--- a/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
@@ -88,7 +88,7 @@ public class CredentialManager: NSObject {
         registrationPromise = Promise()
         authenticationAnchor = request.anchor
         
-        reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.origin!, friendlyName: request.friendlyName))
+        reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
             .flatMap { options -> Result<ASAuthorizationRequest, ReachFiveError> in
                 self.signupOrAddPasskey = .AddPasskey(authToken: authToken)
                 

--- a/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
@@ -122,7 +122,7 @@ public class CredentialManager: NSObject {
         promise = Promise()
         authenticationAnchor = request.anchor
         
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.origin!, scope: request.scopes)
+        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
         scope = webAuthnLoginRequest.scope
         
         reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
@@ -148,7 +148,7 @@ public class CredentialManager: NSObject {
         promise = Promise()
         authenticationAnchor = request.anchor
         
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.origin!, scope: request.scopes)
+        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
         switch username {
         
         case .Unspecified(username: let username):
@@ -190,7 +190,7 @@ public class CredentialManager: NSObject {
         promise = Promise()
         authenticationAnchor = request.anchor
         
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.origin!, scope: request.scopes)
+        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
         
         return signInWith(webAuthnLoginRequest, withMode: mode, authorizing: requestTypes) { authenticationOptions in
             guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 15 context

--- a/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
@@ -87,6 +87,7 @@ public class CredentialManager: NSObject {
         authController?.cancel()
         registrationPromise = Promise()
         authenticationAnchor = request.anchor
+        self.originR5 = request.origin
         
         reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
             .flatMap { options -> Result<ASAuthorizationRequest, ReachFiveError> in
@@ -311,7 +312,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             
             switch signupOrAddPasskey {
             case let .AddPasskey(authToken):
-                registrationPromise.completeWith(reachFiveApi.registerWithWebAuthn(authToken: authToken, publicKeyCredential: registrationPublicKeyCredential))
+                registrationPromise.completeWith(reachFiveApi.registerWithWebAuthn(authToken: authToken, publicKeyCredential: registrationPublicKeyCredential, originR5: self.originR5))
             
             case let .Signup(signupOptions):
                 guard let scope else {

--- a/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
@@ -125,6 +125,7 @@ public class CredentialManager: NSObject {
         authController?.cancel()
         promise = Promise()
         authenticationAnchor = request.anchor
+        originR5 = request.origin
         
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
         scope = webAuthnLoginRequest.scope
@@ -151,6 +152,7 @@ public class CredentialManager: NSObject {
         if #available(iOS 16.0, *) { authController?.cancel() }
         promise = Promise()
         authenticationAnchor = request.anchor
+        originR5 = request.origin
         
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
         switch username {
@@ -193,8 +195,8 @@ public class CredentialManager: NSObject {
         if #available(iOS 16.0, *) { authController?.cancel() }
         promise = Promise()
         authenticationAnchor = request.anchor
-        
         originR5 = request.origin
+        
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
         
         return signInWith(webAuthnLoginRequest, withMode: mode, authorizing: requestTypes) { authenticationOptions in

--- a/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/CredentialManager.swift
@@ -322,8 +322,8 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                     return
                 }
                 
-                let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: signupOptions.options.publicKey.user.id, publicKeyCredential: registrationPublicKeyCredential, originR5: self.originR5)
-                promise.completeWith(reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential)
+                let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: signupOptions.options.publicKey.user.id, publicKeyCredential: registrationPublicKeyCredential)
+                promise.completeWith(reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: self.originR5)
                     .flatMap({ self.loginCallback(tkn: $0.tkn, scope: scope, origin: self.originR5) }))
             }
         } else if #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveApi.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveApi.swift
@@ -87,7 +87,10 @@ public class ReachFiveApi {
         loginProviderRequest: LoginProviderRequest
     ) -> Future<AccessTokenResponse, ReachFiveError> {
         AF
-            .request(createUrl(path: "/identity/v1/oauth/provider/token?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"), method: .post, parameters: loginProviderRequest.dictionary(), encoding: JSONEncoding.default)
+            .request(createUrl(path: "/identity/v1/oauth/provider/token?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"),
+                method: .post,
+                parameters: loginProviderRequest.dictionary(),
+                encoding: JSONEncoding.default)
             .validate(statusCode: 200..<300)
             .validate(contentType: ["application/json"])
             .responseJson(type: AccessTokenResponse.self, decoder: decoder)
@@ -335,6 +338,15 @@ public class ReachFiveApi {
         "https://\(sdkConfig.domain)\(path)"
     }
     
+    //TODO gestion plus générale des query params pour aligner avec buildAuthorizeURL et buildUrl
+    private func path(_ path: String, withParam name: String, value: String?) -> String {
+        if let safe = value?.addingPercentEncoding(withAllowedCharacters: .afURLQueryAllowed) {
+            return "\(path)&\(name)=\(safe)"
+        } else {
+            return path
+        }
+    }
+    
     public func buildAuthorizeURL(queryParams: [String: String]) -> URL {
         let request = try! URLRequest.init(url: createUrl(path: "/oauth/authorize?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"), method: .get, headers: nil)
         let encodedURLRequest = try! URLEncoding.queryString.encode(request, with: queryParams)
@@ -353,15 +365,10 @@ public class ReachFiveApi {
             .responseJson(type: RegistrationOptions.self, decoder: decoder)
     }
     
-    public func signupWithWebAuthn(webauthnSignupCredential: WebauthnSignupCredential) -> Future<AuthenticationToken, ReachFiveError> {
-        var path = "/identity/v1/webauthn/signup?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"
-        if let originR5 = webauthnSignupCredential.originR5 {
-            path += "&origin=\(originR5)"
-        }
-        
-        return AF
+    public func signupWithWebAuthn(webauthnSignupCredential: WebauthnSignupCredential, originR5: String? = nil) -> Future<AuthenticationToken, ReachFiveError> {
+        AF
             .request(
-                createUrl(path: path),
+                createUrl(path: path("/identity/v1/webauthn/signup?platform=ios&sdk=\(sdk)&device=\(deviceInfo)", withParam: "origin", value: originR5)),
                 method: .post,
                 parameters: webauthnSignupCredential.dictionary(),
                 encoding: JSONEncoding.default
@@ -408,14 +415,9 @@ public class ReachFiveApi {
     }
     
     public func registerWithWebAuthn(authToken: AuthToken, publicKeyCredential: RegistrationPublicKeyCredential, originR5: String? = nil) -> Future<(), ReachFiveError> {
-        var path = "/identity/v1/webauthn/registration?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"
-        if let originR5 {
-            path += "&origin=\(originR5)"
-        }
-        
-        return AF
+        AF
             .request(
-                createUrl(path: path),
+                createUrl(path: path("/identity/v1/webauthn/registration?platform=ios&sdk=\(sdk)&device=\(deviceInfo)", withParam: "origin", value: originR5)),
                 method: .post,
                 parameters: publicKeyCredential.dictionary(),
                 encoding: JSONEncoding.default,

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveApi.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveApi.swift
@@ -354,9 +354,14 @@ public class ReachFiveApi {
     }
     
     public func signupWithWebAuthn(webauthnSignupCredential: WebauthnSignupCredential) -> Future<AuthenticationToken, ReachFiveError> {
-        AF
+        var path = "/identity/v1/webauthn/signup?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"
+        if let originR5 = webauthnSignupCredential.originR5 {
+            path += "&origin=\(originR5)"
+        }
+        
+        return AF
             .request(
-                createUrl(path: "/identity/v1/webauthn/signup?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"),
+                createUrl(path: path),
                 method: .post,
                 parameters: webauthnSignupCredential.dictionary(),
                 encoding: JSONEncoding.default

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveApi.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveApi.swift
@@ -407,10 +407,15 @@ public class ReachFiveApi {
             .responseJson(type: RegistrationOptions.self, decoder: decoder)
     }
     
-    public func registerWithWebAuthn(authToken: AuthToken, publicKeyCredential: RegistrationPublicKeyCredential) -> Future<(), ReachFiveError> {
-        AF
+    public func registerWithWebAuthn(authToken: AuthToken, publicKeyCredential: RegistrationPublicKeyCredential, originR5: String? = nil) -> Future<(), ReachFiveError> {
+        var path = "/identity/v1/webauthn/registration?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"
+        if let originR5 {
+            path += "&origin=\(originR5)"
+        }
+        
+        return AF
             .request(
-                createUrl(path: "/identity/v1/webauthn/registration?platform=ios&sdk=\(sdk)&device=\(deviceInfo)"),
+                createUrl(path: path),
                 method: .post,
                 parameters: publicKeyCredential.dictionary(),
                 encoding: JSONEncoding.default,

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
@@ -20,7 +20,7 @@ public extension ReachFive {
     func signup(withRequest request: PasskeySignupRequest) -> Future<AuthToken, ReachFiveError> {
         let domain = sdkConfig.domain
         let signupOptions = SignupOptions(
-            origin: request.origin ?? "https://\(domain)",
+            origin: request.originWebAuthn ?? "https://\(domain)",
             friendlyName: request.friendlyName,
             profile: request.passkeyPofile,
             clientId: sdkConfig.clientId,

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
@@ -71,9 +71,9 @@ public extension ReachFive {
     @available(iOS 16.0, *)
     func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken) -> Future<(), ReachFiveError> {
         let domain = sdkConfig.domain
-        let origin = request.origin ?? "https://\(domain)"
+        let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
         //TODO supprimer l'ancienne passkey du server
-        return credentialManager.registerNewPasskey(withRequest: NewPasskeyRequest(anchor: request.anchor, friendlyName: request.friendlyName, origin: origin), authToken: authToken)
+        return credentialManager.registerNewPasskey(withRequest: NewPasskeyRequest(anchor: request.anchor, friendlyName: request.friendlyName, originWebAuthn: originWebAuthn), authToken: authToken)
     }
     
     private func adapt(_ request: NativeLoginRequest) -> NativeLoginRequest {

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
@@ -27,7 +27,7 @@ public extension ReachFive {
             scope: request.scopes ?? scope
         )
         
-        return credentialManager.signUp(withRequest: signupOptions, anchor: request.anchor)
+        return credentialManager.signUp(withRequest: signupOptions, anchor: request.anchor, originR5: request.origin)
     }
     
     /// Starts an auto-fill assisted passkey login request.

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
@@ -81,7 +81,7 @@ public extension ReachFive {
         let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
         let scopes = request.scopes ?? scope
         
-        return NativeLoginRequest(anchor: request.anchor, originWebAuthn: originWebAuthn, scopes: scopes)
+        return NativeLoginRequest(anchor: request.anchor, originWebAuthn: originWebAuthn, scopes: scopes, origin: request.origin)
     }
 }
 

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
@@ -78,10 +78,10 @@ public extension ReachFive {
     
     private func adapt(_ request: NativeLoginRequest) -> NativeLoginRequest {
         let domain = sdkConfig.domain
-        let origin = request.origin ?? "https://\(domain)"
+        let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
         let scopes = request.scopes ?? scope
         
-        return NativeLoginRequest(anchor: request.anchor, origin: origin, scopes: scopes)
+        return NativeLoginRequest(anchor: request.anchor, originWebAuthn: originWebAuthn, scopes: scopes)
     }
 }
 

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveNative.swift
@@ -73,7 +73,7 @@ public extension ReachFive {
         let domain = sdkConfig.domain
         let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
         //TODO supprimer l'ancienne passkey du server
-        return credentialManager.registerNewPasskey(withRequest: NewPasskeyRequest(anchor: request.anchor, friendlyName: request.friendlyName, originWebAuthn: originWebAuthn), authToken: authToken)
+        return credentialManager.registerNewPasskey(withRequest: NewPasskeyRequest(anchor: request.anchor, friendlyName: request.friendlyName, originWebAuthn: originWebAuthn, origin: request.origin), authToken: authToken)
     }
     
     private func adapt(_ request: NativeLoginRequest) -> NativeLoginRequest {

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/NativeLoginRequest.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/NativeLoginRequest.swift
@@ -5,10 +5,12 @@ public class NativeLoginRequest {
     public let originWebAuthn: String?
     public let scopes: [String]?
     public let anchor: ASPresentationAnchor
+    public let origin: String?
     
-    public init(anchor: ASPresentationAnchor, originWebAuthn: String? = nil, scopes: [String]? = nil) {
+    public init(anchor: ASPresentationAnchor, originWebAuthn: String? = nil, scopes: [String]? = nil, origin: String? = nil) {
         self.originWebAuthn = originWebAuthn
         self.scopes = scopes
         self.anchor = anchor
+        self.origin = origin
     }
 }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/NativeLoginRequest.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/NativeLoginRequest.swift
@@ -2,12 +2,12 @@ import Foundation
 import AuthenticationServices
 
 public class NativeLoginRequest {
-    public let origin: String?
+    public let originWebAuthn: String?
     public let scopes: [String]?
     public let anchor: ASPresentationAnchor
     
-    public init(anchor: ASPresentationAnchor, origin: String? = nil, scopes: [String]? = nil) {
-        self.origin = origin
+    public init(anchor: ASPresentationAnchor, originWebAuthn: String? = nil, scopes: [String]? = nil) {
+        self.originWebAuthn = originWebAuthn
         self.scopes = scopes
         self.anchor = anchor
     }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/NewPasskeyRequest.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/NewPasskeyRequest.swift
@@ -3,12 +3,14 @@ import AuthenticationServices
 
 public class NewPasskeyRequest {
     public let originWebAuthn: String?
+    public let origin: String?
     /// The name that will be displayed by the system when presenting the passkey for login
     public let friendlyName: String
     public let anchor: ASPresentationAnchor
     
-    public init(anchor: ASPresentationAnchor, friendlyName: String, originWebAuthn: String? = nil) {
+    public init(anchor: ASPresentationAnchor, friendlyName: String, originWebAuthn: String? = nil, origin: String? = nil) {
         self.originWebAuthn = originWebAuthn
+        self.origin = origin
         self.friendlyName = friendlyName
         self.anchor = anchor
     }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/NewPasskeyRequest.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/NewPasskeyRequest.swift
@@ -2,13 +2,13 @@ import Foundation
 import AuthenticationServices
 
 public class NewPasskeyRequest {
-    public let origin: String?
+    public let originWebAuthn: String?
     /// The name that will be displayed by the system when presenting the passkey for login
     public let friendlyName: String
     public let anchor: ASPresentationAnchor
     
-    public init(anchor: ASPresentationAnchor, friendlyName: String, origin: String? = nil) {
-        self.origin = origin
+    public init(anchor: ASPresentationAnchor, friendlyName: String, originWebAuthn: String? = nil) {
+        self.originWebAuthn = originWebAuthn
         self.friendlyName = friendlyName
         self.anchor = anchor
     }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/PasskeySignupRequest.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/PasskeySignupRequest.swift
@@ -5,14 +5,14 @@ public class PasskeySignupRequest {
     public let passkeyPofile: ProfilePasskeySignupRequest
     /// The name that will be displayed by the system when presenting the passkey for login
     public let friendlyName: String
-    public let origin: String?
+    public let originWebAuthn: String?
     public let scopes: [String]?
     public let anchor: ASPresentationAnchor
     
-    public init(passkeyPofile: ProfilePasskeySignupRequest, friendlyName: String, anchor: ASPresentationAnchor, origin: String? = nil, scopes: [String]? = nil) {
+    public init(passkeyPofile: ProfilePasskeySignupRequest, friendlyName: String, anchor: ASPresentationAnchor, originWebAuthn: String? = nil, scopes: [String]? = nil) {
         self.passkeyPofile = passkeyPofile
         self.friendlyName = friendlyName
-        self.origin = origin
+        self.originWebAuthn = originWebAuthn
         self.scopes = scopes
         self.anchor = anchor
     }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/PasskeySignupRequest.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/PasskeySignupRequest.swift
@@ -8,12 +8,14 @@ public class PasskeySignupRequest {
     public let originWebAuthn: String?
     public let scopes: [String]?
     public let anchor: ASPresentationAnchor
+    public let origin: String?
     
-    public init(passkeyPofile: ProfilePasskeySignupRequest, friendlyName: String, anchor: ASPresentationAnchor, originWebAuthn: String? = nil, scopes: [String]? = nil) {
+    public init(passkeyPofile: ProfilePasskeySignupRequest, friendlyName: String, anchor: ASPresentationAnchor, originWebAuthn: String? = nil, scopes: [String]? = nil, origin: String? = nil) {
         self.passkeyPofile = passkeyPofile
         self.friendlyName = friendlyName
         self.originWebAuthn = originWebAuthn
         self.scopes = scopes
         self.anchor = anchor
+        self.origin = origin
     }
 }

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/WebauthnSignupCredential.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/WebauthnSignupCredential.swift
@@ -3,10 +3,12 @@ import Foundation
 public class WebauthnSignupCredential: Codable, DictionaryEncodable {
     public var webauthnId: String
     public var publicKeyCredential: RegistrationPublicKeyCredential
+    public var originR5: String?
     
-    public init(webauthnId: String, publicKeyCredential: RegistrationPublicKeyCredential) {
+    public init(webauthnId: String, publicKeyCredential: RegistrationPublicKeyCredential, originR5: String? = nil) {
         self.webauthnId = webauthnId
         self.publicKeyCredential = publicKeyCredential
+        self.originR5 = originR5
     }
 }
 

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/WebauthnSignupCredential.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/webAuthn/WebauthnSignupCredential.swift
@@ -3,12 +3,10 @@ import Foundation
 public class WebauthnSignupCredential: Codable, DictionaryEncodable {
     public var webauthnId: String
     public var publicKeyCredential: RegistrationPublicKeyCredential
-    public var originR5: String?
     
-    public init(webauthnId: String, publicKeyCredential: RegistrationPublicKeyCredential, originR5: String? = nil) {
+    public init(webauthnId: String, publicKeyCredential: RegistrationPublicKeyCredential) {
         self.webauthnId = webauthnId
         self.publicKeyCredential = publicKeyCredential
-        self.originR5 = originR5
     }
 }
 

--- a/Sandbox/Sandbox/ActionController.swift
+++ b/Sandbox/Sandbox/ActionController.swift
@@ -9,7 +9,7 @@ class ActionController: UITableViewController {
         
         guard let window = view.window else { fatalError("The view was not in the app's view hierarchy!") }
         
-        let loginRequest = NativeLoginRequest(anchor: window)
+        let loginRequest = NativeLoginRequest(anchor: window, origin: "ActionController: Section Passkey")
         
         // Section Passkey
         if #available(iOS 16.0, *), indexPath.section == 2 {

--- a/Sandbox/Sandbox/DemoController.swift
+++ b/Sandbox/Sandbox/DemoController.swift
@@ -100,7 +100,7 @@ class DemoController: UIViewController {
                 profile = ProfilePasskeySignupRequest(phoneNumber: username)
             }
             
-            AppDelegate.reachfive().signup(withRequest: PasskeySignupRequest(passkeyPofile: profile, friendlyName: username, anchor: window))
+            AppDelegate.reachfive().signup(withRequest: PasskeySignupRequest(passkeyPofile: profile, friendlyName: username, anchor: window, origin: "DemoController.createAccount"))
                 .onSuccess(callback: goToProfile)
                 .onFailure { error in
                     switch error {

--- a/Sandbox/Sandbox/DemoController.swift
+++ b/Sandbox/Sandbox/DemoController.swift
@@ -68,7 +68,7 @@ class DemoController: UIViewController {
                         return
                     #else
                         if #available(iOS 16.0, *) {
-                            AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: NativeLoginRequest(anchor: window))
+                            AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: NativeLoginRequest(anchor: window, origin: "DemoController.viewDidAppear.AuthCanceled"))
                                 .onSuccess(callback: self.goToProfile)
                                 .onFailure { error in
                                     print("error: \(error) \(error.message())")
@@ -144,7 +144,7 @@ class DemoController: UIViewController {
                         #if targetEnvironment(macCatalyst)
                             return
                         #else
-                            AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: request)
+                            AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: NativeLoginRequest(anchor: window, origin: "DemoController.login.AuthCanceled"))
                                 .onSuccess(callback: self.goToProfile)
                                 .onFailure { error in
                                     print("error: \(error) \(error.message())")

--- a/Sandbox/Sandbox/DemoController.swift
+++ b/Sandbox/Sandbox/DemoController.swift
@@ -160,12 +160,13 @@ class DemoController: UIViewController {
     
     func loginWithPassword() {
         guard let pass = passwordField.text, !pass.isEmpty, let user = usernameField.text, !user.isEmpty else { return }
+        let origin = "DemoController.loginWithPassword"
         
         let fut: Future<AuthToken, ReachFiveError>
         if (user.contains("@")) {
-            fut = AppDelegate.reachfive().loginWithPassword(email: user, password: pass)
+            fut = AppDelegate.reachfive().loginWithPassword(email: user, password: pass, origin: origin)
         } else {
-            fut = AppDelegate.reachfive().loginWithPassword(phoneNumber: user, password: pass)
+            fut = AppDelegate.reachfive().loginWithPassword(phoneNumber: user, password: pass, origin: origin)
         }
         fut.onSuccess(callback: goToProfile)
             .onFailure { error in

--- a/Sandbox/Sandbox/DemoController.swift
+++ b/Sandbox/Sandbox/DemoController.swift
@@ -50,7 +50,7 @@ class DemoController: UIViewController {
         } else {
             mode = .Always
         }
-        AppDelegate.reachfive().login(withRequest: NativeLoginRequest(anchor: window), usingModalAuthorizationFor: types, display: mode)
+        AppDelegate.reachfive().login(withRequest: NativeLoginRequest(anchor: window, origin: "DemoController.viewDidAppear"), usingModalAuthorizationFor: types, display: mode)
             .onSuccess(callback: goToProfile)
             .onFailure { error in
                 
@@ -130,7 +130,7 @@ class DemoController: UIViewController {
         }
         
         if #available(iOS 16.0, *) {
-            let request = NativeLoginRequest(anchor: window)
+            let request = NativeLoginRequest(anchor: window, origin: "DemoController.login")
             
             (username.isEmpty ?
                 // this is optional, but a good way to present a modal with a fallback to QR code for loging using a nearby device

--- a/Sandbox/Sandbox/LoginPasskeyController.swift
+++ b/Sandbox/Sandbox/LoginPasskeyController.swift
@@ -38,7 +38,7 @@ class LoginPasskeyController: UIViewController {
                     #if targetEnvironment(macCatalyst)
                         return
                     #else
-                        AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: NativeLoginRequest(anchor: window))
+                        AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: NativeLoginRequest(anchor: window, origin: "LoginPasskeyController.viewDidAppear.AuthCanceled"))
                             .onSuccess(callback: self.goToProfile)
                             .onFailure { error in
                                 let alert = AppDelegate.createAlert(title: "Login", message: "Error: \(error.message())")
@@ -70,7 +70,7 @@ class LoginPasskeyController: UIViewController {
                     #if targetEnvironment(macCatalyst)
                         return
                     #else
-                        AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: request)
+                        AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: NativeLoginRequest(anchor: window, origin: "LoginPasskeyController.nonDiscoverableLogin.AuthCanceled"))
                             .onSuccess(callback: self.goToProfile)
                             .onFailure { error in
                                 let alert = AppDelegate.createAlert(title: "Login", message: "Error: \(error.message())")

--- a/Sandbox/Sandbox/LoginPasskeyController.swift
+++ b/Sandbox/Sandbox/LoginPasskeyController.swift
@@ -105,7 +105,7 @@ class LoginPasskeyController: UIViewController {
         }
         
         let window: UIWindow = view.window!
-        AppDelegate.reachfive().signup(withRequest: PasskeySignupRequest(passkeyPofile: profile, friendlyName: username, anchor: window))
+        AppDelegate.reachfive().signup(withRequest: PasskeySignupRequest(passkeyPofile: profile, friendlyName: username, anchor: window, origin: "LoginPasskeyController.createAccount"))
             .onSuccess(callback: goToProfile)
             .onFailure { error in
                 let alert = AppDelegate.createAlert(title: "Signup", message: "Error: \(error.message())")

--- a/Sandbox/Sandbox/LoginPasskeyController.swift
+++ b/Sandbox/Sandbox/LoginPasskeyController.swift
@@ -24,7 +24,7 @@ class LoginPasskeyController: UIViewController {
         print("viewDidAppear")
         
         guard let window = view.window else { fatalError("The view was not in the app's view hierarchy!") }
-        AppDelegate.reachfive().login(withRequest: NativeLoginRequest(anchor: window), usingModalAuthorizationFor: [.Passkey], display: .IfImmediatelyAvailableCredentials)
+        AppDelegate.reachfive().login(withRequest: NativeLoginRequest(anchor: window, origin: "LoginPasskeyController.viewDidAppear"), usingModalAuthorizationFor: [.Passkey], display: .IfImmediatelyAvailableCredentials)
             .onSuccess(callback: goToProfile)
             .onFailure { error in
                 
@@ -55,7 +55,7 @@ class LoginPasskeyController: UIViewController {
     @IBAction func nonDiscoverableLogin(_ sender: Any) {
         guard let window = view.window else { fatalError("The view was not in the app's view hierarchy!") }
         let fut: Future<AuthToken, ReachFiveError>
-        let request = NativeLoginRequest(anchor: window)
+        let request = NativeLoginRequest(anchor: window, origin: "LoginPasskeyController.nonDiscoverableLogin")
         switch (usernameField.text) {
         case .none, .some(""):
             // this is optional, but a good way to present a modal with a fallback to QR code for loging using a nearby device

--- a/Sandbox/Sandbox/NativePasswordController.swift
+++ b/Sandbox/Sandbox/NativePasswordController.swift
@@ -31,7 +31,7 @@ class NativePasswordController: UIViewController {
         guard let window = view.window else { fatalError("The view was not in the app's view hierarchy!") }
         
         AppDelegate.reachfive()
-            .login(withRequest: NativeLoginRequest(anchor: window), usingModalAuthorizationFor: [.Password], display: .Always)
+            .login(withRequest: NativeLoginRequest(anchor: window, origin: "NativePasswordController.viewDidAppear"), usingModalAuthorizationFor: [.Password], display: .Always)
             .onSuccess(callback: goToProfile)
             .onFailure { error in
                 switch error {

--- a/Sandbox/Sandbox/PasskeyAutoFillController.swift
+++ b/Sandbox/Sandbox/PasskeyAutoFillController.swift
@@ -11,7 +11,7 @@ class PasskeyAutoFillControler: UIViewController {
             
             if #available(iOS 16.0, *) {
                 guard let window = view.window else { fatalError("The view was not in the app's view hierarchy!") }
-                AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: NativeLoginRequest(anchor: window))
+                AppDelegate.reachfive().beginAutoFillAssistedPasskeyLogin(withRequest: NativeLoginRequest(anchor: window, origin: "PasskeyAutoFillControler.viewDidAppear"))
                     .onSuccess(callback: goToProfile)
                     .onFailure { error in
                         let alert = AppDelegate.createAlert(title: "Login", message: "Error: \(error.message())")

--- a/Sandbox/Sandbox/PasskeyNonDiscoverableController.swift
+++ b/Sandbox/Sandbox/PasskeyNonDiscoverableController.swift
@@ -18,7 +18,7 @@ class PasskeyNonDiscoverableController: UIViewController {
         guard let window = view.window else { fatalError("The view was not in the app's view hierarchy!") }
         guard let username = username.text, !username.isEmpty else { return }
         
-        let request = NativeLoginRequest(anchor: window)
+        let request = NativeLoginRequest(anchor: window, origin: "PasskeyNonDiscoverableController.login")
         AppDelegate.reachfive().login(withNonDiscoverableUsername: .Unspecified(username), forRequest: request, usingModalAuthorizationFor: [.Passkey], display: mode)
             .onSuccess(callback: goToProfile)
             .onFailure { error in

--- a/Sandbox/Sandbox/ProfileController.swift
+++ b/Sandbox/Sandbox/ProfileController.swift
@@ -182,7 +182,7 @@ class ProfileController: UIViewController {
                 let registerAction = UIAlertAction(title: "Add", style: .default) { [unowned alert] (_) in
                     let textField = alert.textFields?[0]
                     
-                    AppDelegate.reachfive().registerNewPasskey(withRequest: NewPasskeyRequest(anchor: window, friendlyName: textField?.text ?? friendlyName), authToken: authToken)
+                    AppDelegate.reachfive().registerNewPasskey(withRequest: NewPasskeyRequest(anchor: window, friendlyName: textField?.text ?? friendlyName, origin: "ProfileController.registerNewPasskey"), authToken: authToken)
                         .onSuccess { _ in
                             self.reloadCredentials(authToken: authToken)
                         }

--- a/Sandbox/Sandbox/SignupPasskeyController.swift
+++ b/Sandbox/Sandbox/SignupPasskeyController.swift
@@ -26,7 +26,7 @@ class SignupPasskeyController: UIViewController {
         
         if #available(iOS 16.0, *) {
             let window: UIWindow = view.window!
-            AppDelegate.reachfive().signup(withRequest: PasskeySignupRequest(passkeyPofile: profile, friendlyName: username, anchor: window))
+            AppDelegate.reachfive().signup(withRequest: PasskeySignupRequest(passkeyPofile: profile, friendlyName: username, anchor: window, origin: "SignupPasskeyController.signup"))
                 .onSuccess(callback: goToProfile)
                 .onFailure { error in
                     switch (error) {


### PR DESCRIPTION
[Rename origin parameters in SDKs to avoid conflict with business origin attribute](https://reach5.atlassian.net/browse/CA-3210)

Dans les classes exposées au intégrateurs : BREAKING CHANGE
- Renommge du paramètre "origin" utile à webauthn en "originWebAuthn"
- Ajout du paramètre "origin" au sens de Reach5 pour les évènements utilisateurs

Dans les classes internes exposées au backend ciam-app : 
- on garde le paramètre "origin" utile à webauthn tel quel. Il est passé uniquement en corps de requête.
- on ajoute un paramètre originR5 pour l'origine  au sens de Reach5. Il est ajouté en query params aux appels backend
Donc pas de problème de compatibilité ou de modifs à faire dans le back.