### PR TITLE
Bug sur le webviewLogin

### DIFF
--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveWebviewLogin.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveWebviewLogin.swift
@@ -44,9 +44,8 @@ public extension ReachFive {
         session.presentationContextProvider = request.presentationContextProvider
         
         // Start the Authentication Flow
-        if !session.start() {
-            promise.failure(.TechnicalError(reason: "Failed to start ASWebAuthenticationSession"))
-        }
+        // if the result of this method is false then the error will already have been processed and the promise failed in the callback
+        session.start()
         return promise.future
     }
 }


### PR DESCRIPTION
Si on lance une `ASWebAuthenticationSession` rapidement après avoir annulé un lancement précédent, l'app plante.
Ceci est dû au fait que la promesse est remplie en erreur une première fois avec `.TechnicalError(reason: "Presentation Context Invalid")` puis une deuxième fois avec `.TechnicalError(reason: "Failed to start ASWebAuthenticationSession")`

Correctif : 
ne pas essayer de remplir la promesse si le `start` retourne `false`