### PR TITLE
Correction de beug de scope dans la connexion par webview

### DIFF
--- a/IdentitySdkCore/IdentitySdkCore/Classes/DefaultProvider.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/DefaultProvider.swift
@@ -24,7 +24,7 @@ class DefaultProvider: NSObject, Provider {
             return Future(error: .TechnicalError(reason: "No presenting viewController"))
         }
         
-        return reachfive.webviewLogin(WebviewLoginRequest(state: "state", nonce: "nonce", scope: scope, presentationContextProvider: presentationContextProvider, origin: origin, provider: providerConfig.provider))
+        return reachfive.webviewLogin(WebviewLoginRequest(scope: scope, presentationContextProvider: presentationContextProvider, origin: origin, provider: providerConfig.provider))
     }
     
     override var description: String {

--- a/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveWebviewLogin.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/ReachFiveWebviewLogin.swift
@@ -9,6 +9,7 @@ public extension ReachFive {
         let promise = Promise<AuthToken, ReachFiveError>()
         
         let pkce = Pkce.generate()
+        let scope = (request.scope ?? scope)
         let authURL = buildAuthorizeURL(pkce: pkce, state: request.state, nonce: request.nonce, scope: scope, origin: request.origin, provider: request.provider)
         
         // Initialize the session.

--- a/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/WebviewLoginRequest.swift
+++ b/IdentitySdkCore/IdentitySdkCore/Classes/models/requests/WebviewLoginRequest.swift
@@ -9,9 +9,9 @@ public class WebviewLoginRequest {
     public let origin: String?
     public let provider: String?
     
-    public init(state: String, nonce: String, scope: [String]?, presentationContextProvider: ASWebAuthenticationPresentationContextProviding, origin: String? = nil, provider: String? = nil) {
-        self.state = state
-        self.nonce = nonce
+    public init(state: String? = nil, nonce: String? = nil, scope: [String]? = nil, presentationContextProvider: ASWebAuthenticationPresentationContextProviding, origin: String? = nil, provider: String? = nil) {
+        self.state = state ?? "state"
+        self.nonce = nonce ?? "nonce"
         self.scope = scope
         self.presentationContextProvider = presentationContextProvider
         self.origin = origin

--- a/Sandbox/Sandbox/ActionController.swift
+++ b/Sandbox/Sandbox/ActionController.swift
@@ -32,7 +32,7 @@ class ActionController: UITableViewController {
             // standard webview
             if indexPath.row == 0 {
                 AppDelegate.reachfive()
-                    .webviewLogin(WebviewLoginRequest(state: "state", nonce: "nonce", scope: ["email", "profile"], presentationContextProvider: self, origin: "ActionController.webviewLogin"))
+                    .webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin"))
                     .onComplete { self.handleResult(result: $0) }
             }
         }


### PR DESCRIPTION
Quand j'ai fait le refacto en 5.8 pour intégrer le Provider web "par défaut" j'ai oublié de reprendre l'initialisation du scope.
J'en profite pour passer le paramètre en optionnel.