### PR TITLE
Suppression du label dans l'appel de mfaDeleteCredential

### DIFF
--- a/Sandbox/Sandbox/MfaController.swift
+++ b/Sandbox/Sandbox/MfaController.swift
@@ -396,7 +396,7 @@ extension CredentialCollectionViewCell {
                     }
             } else {
                 AppDelegate.reachfive()
-                    .mfaDeleteCredential(phoneNumber: identifier, authToken: authToken)
+                    .mfaDeleteCredential(identifier, authToken: authToken)
                     .onSuccess { _ in
                         self.contentView.removeFromSuperview()
                     }


### PR DESCRIPTION
#162 avait retiré le label de la définition de la méthode, mais sans le retirer de son utilisation dans la Sandbox.